### PR TITLE
begin the non-Windows support work

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet build",
+            "type": "shell",
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/src"
+            },
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/SamplePlugin/CloseStreamDeck.sh
+++ b/src/SamplePlugin/CloseStreamDeck.sh
@@ -1,0 +1,3 @@
+﻿echo 'Killing the stream deck process'
+pkill 'Stream Deck'
+exit

--- a/src/SamplePlugin/MySamplePlugin.cs
+++ b/src/SamplePlugin/MySamplePlugin.cs
@@ -57,6 +57,5 @@ namespace SamplePlugin
             settings.counter = _Counter;
             await Manager.SetSettingsAsync(args.context, settings);
         }
-
     }
 }

--- a/src/SamplePlugin/SamplePlugin.csproj
+++ b/src/SamplePlugin/SamplePlugin.csproj
@@ -77,11 +77,12 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="powershell -ExecutionPolicy Unrestricted -file &quot;$(ProjectDir)RegisterPluginAndStartStreamDeck.ps1&quot;" />
+	  <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell -ExecutionPolicy Unrestricted -file &quot;$(ProjectDir)RegisterPluginAndStartStreamDeck.ps1&quot;" />
 	</Target>
 
 	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-	  <Exec Command="powershell -ExecutionPolicy Unrestricted -file &quot;$(ProjectDir)CloseStreamDeck.ps1&quot;" />
+	  <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell -ExecutionPolicy Unrestricted -file &quot;$(ProjectDir)CloseStreamDeck.ps1&quot;" />
+    <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="bash &quot;$(ProjectDir)CloseStreamDeck.sh&quot;" />
 	</Target>
 
 </Project>

--- a/src/SamplePlugin/SamplePlugin.csproj
+++ b/src/SamplePlugin/SamplePlugin.csproj
@@ -76,11 +76,11 @@
 	  </None>
 	</ItemGroup>
 
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)'=='Debug'">
 	  <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell -ExecutionPolicy Unrestricted -file &quot;$(ProjectDir)RegisterPluginAndStartStreamDeck.ps1&quot;" />
 	</Target>
 
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+	<Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition=" '$(Configuration)'=='Debug'">
 	  <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell -ExecutionPolicy Unrestricted -file &quot;$(ProjectDir)CloseStreamDeck.ps1&quot;" />
     <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="bash &quot;$(ProjectDir)CloseStreamDeck.sh&quot;" />
 	</Target>


### PR DESCRIPTION
This PR includes a script that kills the Stream Deck process from Bash. This would enable non-Windows users to build and run the code. This fixes #11 and is a quasi-duplicate of #13, so #13 can be closed as I'll be taking @AdmiralSnyder's work into this and the next PR I submit. (Thanks for the inspiration, BTW!)