### PR TITLE
Removed extra parentheses

### DIFF
--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/Program.cs
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/Program.cs
@@ -47,7 +47,7 @@ namespace _StreamDeckPlugin_
 			try
 			{
 				await ConnectionManager.Initialize(Port, PluginUUID, RegisterEvent, Info, loggerFactory)
-					.SetPlugin(new $(PluginName))())
+					.SetPlugin(new $(PluginName)())
 					.StartAsync(source.Token);
 				
 				Console.ReadLine();	


### PR DESCRIPTION
I believe this is a bug, unless I did something wrong. $(PluginName) is replaced by actual plugin name when template started.

Prior to this change, it resulted in the following on line 50 of Program.cs, which doesn't compile:

`SetPlugin(new MyPlugin)())`

This removes the extra parentheses, making it:

`.SetPlugin(new MyPlugin())`