### PR TITLE
Added System.Threading.Tasks reference to plugin template class

### DIFF
--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/_PluginName_.cs
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/_PluginName_.cs
@@ -1,5 +1,6 @@
 ﻿using StreamDeckLib;
 using StreamDeckLib.Messages;
+using System.Threading.Tasks;
 
 namespace _StreamDeckPlugin_
 {


### PR DESCRIPTION
In the template, the plugin stubs out a method for:

`public override async Task OnKeyUp(StreamDeckEventPayload args)`

Reference to System.Threading.Tasks isn't included, making initial build fail when using the template.