### PR TITLE
(Optional) Add stub return statement for plugin template

### DIFF
--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/_PluginName_.cs
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/_PluginName_.cs
@@ -9,7 +9,7 @@ namespace _StreamDeckPlugin_
 		{
 			// Your plugin code goes here.
 
-			return;
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/_PluginName_.cs
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/_PluginName_.cs
@@ -8,6 +8,8 @@ namespace _StreamDeckPlugin_
 		public override async Task OnKeyUp(StreamDeckEventPayload args)
 		{
 			// Your plugin code goes here.
+
+			return;
 		}
 	}
 }


### PR DESCRIPTION
The last of my 3 small pull requests, this one is optional. 

The last step to ensure the plugin template builds as soon as it's created is to actually return something in the OnKeyUp hook in the template. It's a Task return type, so I just returned nothing for now.

Hopefully with these three, you can go from `dotnet new <>` to `dotnet build`.