### PR TITLE
Added vscode workspace stub

### DIFF
--- a/StreamDeckToolkit.code-workspace
+++ b/StreamDeckToolkit.code-workspace
@@ -1,0 +1,18 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"files.exclude": {
+			"**/obj/": true,
+			"**/bin/": true,
+		}
+	},
+	"extensions": {
+		"recommendations": [
+			"ms-vscode.csharp"
+		]
+	}
+}


### PR DESCRIPTION
Added a simple stub VSCode workspace to act as a placeholder to build upon. It includes:

- Settings to add file exclusions that hide transitory C# compiler/debugger files in the obj and bin folders from the VSCode explorer pane
- Example "recommended extensions" for the Microsoft C# extension. This allows us to add further recommendations as we need to support any other tooling, or even maybe a StreamDeckToolkit extension!

For future consideration; moving tasks and launch settings into the workspace.