### PR TITLE
register plugin tidy up

### DIFF
--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/RegisterPluginAndStartStreamDeck.sh
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/RegisterPluginAndStartStreamDeck.sh
@@ -1,10 +1,30 @@
+#!/usr/bin/env bash
+
+#Notify user of action.
 echo 'Killing the stream deck process'
+
+#Kill the process.
 pkill 'Stream Deck'
-uuid=$(jq .Actions[0].UUID manifest.json)
+
+#Pull the UUID from the manifest.json
+uuid=$(sed -n 's/.*"UUID": "\(.*\)"/\1/p' manifest.json)
+
+#Define suffix
 suffix=".action"
+
 pluginName=$(echo "$uuid" | tr -d \" | sed -e "s/$suffix$//")
-echo 'Installing the $pluginName plugin...'
-rm -r ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin
+
+#Notify user of Action.
+echo "Installing the $pluginName plugin..."
+
+#On first run the file does not exist, we ignore errors from removing it.
+#Not elegant, and needs love.
+rm -r ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin 2> /dev/null || echo > /dev/null
+
+#Recreate directory for plugin.
 mkdir ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin
+
+#Move our build into folder.
 cp bin/Debug/netcoreapp2.2/* ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin
+
 exit

--- a/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
+++ b/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
@@ -1,10 +1,30 @@
+#!/usr/bin/env bash
+
+#Notify user of action.
 echo 'Killing the stream deck process'
+
+#Kill the process.
 pkill 'Stream Deck'
-uuid=$(jq .Actions[0].UUID manifest.json)
+
+#Pull the UUID from the manifest.json
+uuid=$(sed -n 's/.*"UUID": "\(.*\)"/\1/p' manifest.json)
+
+#Define suffix
 suffix=".action"
+
 pluginName=$(echo "$uuid" | tr -d \" | sed -e "s/$suffix$//")
-echo 'Installing the $pluginName plugin...'
-rm -r ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin
+
+#Notify user of Action.
+echo "Installing the $pluginName plugin..."
+
+#On first run the file does not exist, we ignore errors from removing it.
+#Not elegant, and needs love.
+rm -r ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin 2> /dev/null || echo > /dev/null
+
+#Recreate directory for plugin.
 mkdir ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin
+
+#Move our build into folder.
 cp bin/Debug/netcoreapp2.2/* ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin
+
 exit


### PR DESCRIPTION
- Added liberal comments
- Removed jq, it is great, but not on a system with a standard installation. The sed solution #workedonmymachine
- Added #shebang

I'm not sure about the last line. 
`cp bin/Debug/netcoreapp2.2/* ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/$pluginName.sdPlugin`

I don't know that the stream deck software will run a *.dll from the build directory. My assumption is that we will need to run dotnet build --runtime osx-x64 and copy from the resulting netcoreapp2.2/osx-64/ directory and reference the compiled binary, but have not gotten that far.