### PR TITLE
rename build task name and add a build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,8 +4,21 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
+            "label": "build osx-x64",
             "command": "dotnet build --runtime osx-x64",
+            "type": "shell",
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/src"
+            },
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build win10-x64",
+            "command": "dotnet build --runtime win10-x64",
             "type": "shell",
             "group": "build",
             "options": {


### PR DESCRIPTION
Renamed the existing build task to indicate that it is the build task for OSX-x64.
I also added a build task for win10-x64 for the folks who want to build it for  *gasp* Windows in VSCode ;-)

This is not tested on OSX (I don't have a Mac!!) nor I have (yet) a StreamDeck and I quickly edited this in GitHub while watching the recording.