### PR TITLE
Choose default RID based on the build platform

### DIFF
--- a/src/SamplePlugin/SamplePlugin.csproj
+++ b/src/SamplePlugin/SamplePlugin.csproj
@@ -4,7 +4,9 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>netcoreapp2.2</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition=" '$(OS)' == 'Windows_NT' and '$(Configuration)'=='Debug' ">win-x64</RuntimeIdentifier> <!-- When building/running on Windows -->
+		<RuntimeIdentifier Condition=" '$(OS)' != 'Windows_NT' and '$(Configuration)'=='Debug' ">osx-x64</RuntimeIdentifier> <!-- When on non-Windows environment, assume macOS for now -->
+		<RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers> <!-- At this time, the only platforms we are really targetting, and supported by the Stream Deck SDK are Windows and macOS  -->
 		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
 	</PropertyGroup>
 

--- a/src/SamplePlugin/SamplePlugin.csproj
+++ b/src/SamplePlugin/SamplePlugin.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<RuntimeIdentifier Condition=" '$(OS)' == 'Windows_NT' and '$(Configuration)'=='Debug' ">win-x64</RuntimeIdentifier> <!-- When building/running on Windows -->
 		<RuntimeIdentifier Condition=" '$(OS)' != 'Windows_NT' and '$(Configuration)'=='Debug' ">osx-x64</RuntimeIdentifier> <!-- When on non-Windows environment, assume macOS for now -->
-		<RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers> <!-- At this time, the only platforms we are really targetting, and supported by the Stream Deck SDK are Windows and macOS  -->
+		<RuntimeIdentifiers Condition="'$(Configuration)'=='Release' ">win-x64;osx-x64</RuntimeIdentifiers> <!-- At this time, the only platforms we are really targetting, and supported by the Stream Deck SDK are Windows and macOS  -->
 		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
 	</PropertyGroup>
 


### PR DESCRIPTION
Only applied for the `Debug` configuration. `Release` will/should require the target RID(s) to be specified, unless we update the `.csproj` with different rules.

This addresses issue #56