### PR TITLE
OS X Workflow Updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ csharp_style_var_for_built_in_types = true:error
 csharp_style_var_when_type_is_apparent = true:error
 csharp_style_var_elsewhere = true:error
 csharp_prefer_braces = true
+
+[*.sh]
+end_of_line = lf

--- a/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
+++ b/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
@@ -1,37 +1,22 @@
-#!/usr/bin/env bash
-
-#Define Plugin Directory
-PLUGIN_DIR="~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/${pluginName.sdPlugin}"
-#Define suffix
-SUFFIX=".action"
-
-#Notify user of action.
-echo 'Killing the stream deck process'
-
-#Kill the process.
+echo 'Killing the Stream Deck process'
 pkill 'Stream Deck'
 
-#Pull the UUID from the manifest.json
-uuid=$(sed -n 's/.*"UUID": "\(.*\)"/\1/p' manifest.json)
+uuid=$(jq -r .Actions[0].UUID manifest.json)
+pluginName=${uuid%.*}
+pluginsDir="$HOME/Library/Application Support/com.elgato.StreamDeck/Plugins"
+projectDir=$(PWD)
 
-pluginName=$(echo "${uuid}" | tr -d \" | sed -e "s/${SUFFIX}$//")
 
-#Notify user of Action.
-echo "Installing the ${pluginName} plugin..."
+echo "Installing the $pluginName plugin to $pluginsDir"
 
-#On first run the file does not exist, we check if it exists.
-if [ -d ${PLUGIN_DIR} ]; then rm -fr ${PLUGIN_DIR}; fi
+pushd "$pluginsDir"
+[ -d "$pluginName.sdPlugin" ] && rm -r $pluginName.sdPlugin
+mkdir $pluginName.sdPlugin
+cp -R "$projectDir/bin/Debug/netcoreapp2.2/osx-x64/." $pluginName.sdPlugin
+popd
 
-#Recreate directory for plugin.
-mkdir -p ${PLUGIN_DIR}
+echo "Done installing ${pluginName}"
 
-#Move our build into folder.
-cp bin/Debug/netcoreapp2.2/* ${PLUGIN_DIR}
-
-#Notify user of Action.
-echo "Done installing ${pluginName}."
-
-#start the stream deck
 open /Applications/Stream\ Deck.app &
 
 exit

--- a/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
+++ b/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
@@ -1,3 +1,5 @@
+command -v jq >/dev/null 2>&1 || { echo >&2 "Aborting. This script requires jq. Please visit: https://stedolan.github.io/jq/"; exit 1; }
+
 echo 'Killing the Stream Deck process'
 pkill 'Stream Deck'
 

--- a/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
+++ b/src/SamplePlugin/RegisterPluginAndStartStreamDeck.sh
@@ -1,9 +1,7 @@
-command -v jq >/dev/null 2>&1 || { echo >&2 "Aborting. This script requires jq. Please visit: https://stedolan.github.io/jq/"; exit 1; }
-
 echo 'Killing the Stream Deck process'
 pkill 'Stream Deck'
 
-uuid=$(jq -r .Actions[0].UUID manifest.json)
+uuid=$(sed -n 's/.*"UUID": "\(.*\)"/\1/p' manifest.json)
 pluginName=${uuid%.*}
 pluginsDir="$HOME/Library/Application Support/com.elgato.StreamDeck/Plugins"
 projectDir=$(PWD)

--- a/src/SamplePlugin/manifest.json
+++ b/src/SamplePlugin/manifest.json
@@ -1,35 +1,35 @@
 {
   "Actions": [
     {
-      "Icon": "actionIcon", 
-      "Name": "SamplePlugin", 
+      "Icon": "actionIcon",
+      "Name": "SamplePlugin",
       "States": [
         {
           "Image": "actionDefaultImage",
-          "TitleAlignment": "middle", 
+          "TitleAlignment": "middle",
           "FontSize": "16"
         }
-      ], 
+      ],
       "SupportedInMultiActions": false,
-      "Tooltip": "How many times did you get pwned today? Keep track with this counter.", 
+      "Tooltip": "How many times did you get pwned today? Keep track with this counter.",
       "UUID": "com.csharpfritz.samplePlugin.action"
     }
-  ], 
+  ],
   "Author": "Jeffrey T. Fritz",
-	"CodePathWin": "SamplePlugin.exe", 
-	"CodePathMac":  "StreamDeck_First",
-  "Description": "The Sample Plugin", 
-  "Name": "Sample Plugin", 
-  "Icon": "pluginIcon", 
-  "URL": "https://www.elgato.com/gaming/stream-deck", 
+	"CodePathWin": "SamplePlugin.exe",
+	"CodePathMac":  "SamplePlugin",
+  "Description": "The Sample Plugin",
+  "Name": "Sample Plugin",
+  "Icon": "pluginIcon",
+  "URL": "https://www.elgato.com/gaming/stream-deck",
   "Version": "1.2",
   "OS": [
     {
-        "Platform": "mac", 
+        "Platform": "mac",
         "MinimumVersion" : "10.11"
     },
     {
-        "Platform": "windows", 
+        "Platform": "windows",
         "MinimumVersion" : "10"
     }
   ]


### PR DESCRIPTION
Fixes #42 

Hey, this is [Auth0Bobby](https://www.twitch.tv/auth0bobby) from Twitch! I took some time today to try to get this building under OS X. The post-build bash script had a few issues that were perplexing and fun to track down. 

First, it seemed as if the file might have been created on windows, this led to the file encoding being all b0rked and `?` being added to some strings. 

Next, the `.editorconfig` was forcing `end_of_line` to `crlf` on files. So editing the file in VSCode was inserting bad line endings for OS X. I updated the editor config to set it to `lf` for all `.sh` files.

```
[*.sh]
end_of_line = lf
```

Next, the fact that the plugins directory is located in `~/Library/Application Support/...` was causing some commands to break. These commands were seeing the space as a separator and b0rking. Also, the script has a dependency on `jq`, but does not handle the case where `jq` is missing. I rewrote the entire script to simplify it and make it work as expected. Here is a brief explanation of what it all does.

```bash
echo 'Killing the Stream Deck process'
pkill 'Stream Deck'

 # use sed to get the uuid
uuid=$(sed -n 's/.*"UUID": "\(.*\)"/\1/p' manifest.json)
 # use parameter expansion to trip the suffix off the uuid to get the pluginname
pluginName=${uuid%.*}
# set a variable to the plugin directory so we don't have to type it over and over
pluginsDir="$HOME/Library/Application Support/com.elgato.StreamDeck/Plugins"
# set a variable to the current working directory
projectDir=$(PWD)


echo "Installing the $pluginName plugin to $pluginsDir"

# push the plugin directory on to the working directory stack
pushd "$pluginsDir"
# check of the plugin directory exists and nuke it if it does
[ -d "$pluginName.sdPlugin" ] && rm -r $pluginName.sdPlugin
# create the plugin directory
mkdir $pluginName.sdPlugin
# copy recursively the build output from the project directory tot he plugin directory
cp -R "$projectDir/bin/Debug/netcoreapp2.2/osx-x64/." $pluginName.sdPlugin
# pop the current directory off the working directory stack
popd

echo "Done installing ${pluginName}"

open /Applications/Stream\ Deck.app &

exit
```

Finally, the `manifest.json` had the `CodePathMac` value pointing to something that did not exist. I set it to the correct executable name.

```json
{
    "CodePathWin": "SamplePlugin.exe",
    "CodePathMac":  "SamplePlugin"
}
```

Here is a short gif showing the build working on my machine. :grin:

![build](https://user-images.githubusercontent.com/73120/51805467-79d8e200-2222-11e9-86e9-ece5f6c9d720.gif)
