### PR TITLE
Fix command line flag to install template

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Uninstall the local template by running.
 
 ### From NuGet
 
-    dotnet add package StreamDeckPluginTemplate
+    dotnet new -i StreamDeckPluginTemplate
     - OR -
-    Install-Package StreamDeckPluginTemplate -Version 0.2.286
+    Install-Package StreamDeckPluginTemplate [-Version x.y.zzz]
 
 ## Using the Template
 


### PR DESCRIPTION
Fix the command line to install the template from NuGet
Mark the `Version` parameter as optional in the PowerShell (`Install-Package`) call

Fixes issue: #71