### PR TITLE
Prevent displaying errors in PowerShell script to the user

### DIFF
--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/RegisterPluginAndStartStreamDeck.ps1
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/RegisterPluginAndStartStreamDeck.ps1
@@ -1,4 +1,4 @@
-﻿﻿Write-Host "Gathering deployment items..."
+﻿Write-Host "Gathering deployment items..."
 
 Write-Host "Script root: $PSScriptRoot`n"
 
@@ -23,7 +23,7 @@ $targetFrameworkName = $projectXML.Project.PropertyGroup.TargetFramework;
 $streamDeckExePath = "$($ENV:ProgramFiles)\Elgato\StreamDeck\StreamDeck.exe"
 
 # For now, this PS script will only be run on Windows.
-$bindir = "$basePath\bin\Debug\$targetFrameworkName\win-x64\"
+$bindir = "$basePath\bin\Debug\$targetFrameworkName\win-x64"
 
 # Make sure we actually have a directory/build to deploy
 If (-not (Test-Path $bindir)) {
@@ -43,17 +43,19 @@ $destDir = "$($env:APPDATA)\Elgato\StreamDeck\Plugins\$pluginID.sdPlugin"
 
 $pluginName = Split-Path $basePath -leaf
 
-Get-Process StreamDeck,$pluginName | Stop-Process –force -ErrorAction SilentlyContinue
+Get-Process -Name ("StreamDeck", $pluginName) -ErrorAction SilentlyContinue | Stop-Process –force -ErrorAction SilentlyContinue
 
 # Delete the target directory, make sure the deployment/copy is clean
-Remove-Item -Recurse -Path $destDir
+If (Test-Path $destDir) {
+  Remove-Item -Recurse -Force -Path $destDir 
+}
 
 # Then copy all deployment items to the plugin directory
 New-Item -Type Directory -Path $destDir -ErrorAction SilentlyContinue # | Out-Null
-Push-Location $bindir
-Copy-Item -Path "$bindir\*.*" -Destination $destDir -Recurse
-Pop-Location
+$bindir = $bindir +"\*"
+Copy-Item -Path $bindir -Destination $destDir -Recurse
 
-Write-Host "Deployment complete. Restarting Stream Deck..."
+
+Write-Host "Deployment complete. Restarting the Stream Deck desktop application..."
 Start-Process $streamDeckExePath
 exit 0

--- a/src/SamplePlugin/RegisterPluginAndStartStreamDeck.ps1
+++ b/src/SamplePlugin/RegisterPluginAndStartStreamDeck.ps1
@@ -1,4 +1,4 @@
-﻿﻿Write-Host "Gathering deployment items..."
+﻿Write-Host "Gathering deployment items..."
 
 Write-Host "Script root: $PSScriptRoot`n"
 
@@ -43,11 +43,13 @@ $destDir = "$($env:APPDATA)\Elgato\StreamDeck\Plugins\$pluginID.sdPlugin"
 
 $pluginName = Split-Path $basePath -leaf
 
-Get-Process StreamDeck,$pluginName | Stop-Process –force -ErrorAction SilentlyContinue
+Get-Process -Name ("StreamDeck", $pluginName) -ErrorAction SilentlyContinue | Stop-Process –force -ErrorAction SilentlyContinue
 
 # Delete the target directory, make sure the deployment/copy is clean
-Remove-Item -Recurse -Force -Path $destDir
-$bindir = $bindir +"\*"
+If (Test-Path $destDir) {
+  Remove-Item -Recurse -Force -Path $destDir 
+  $bindir = $bindir +"\*"
+}
 
 # Then copy all deployment items to the plugin directory
 New-Item -Type Directory -Path $destDir -ErrorAction SilentlyContinue # | Out-Null

--- a/src/SamplePlugin/RegisterPluginAndStartStreamDeck.ps1
+++ b/src/SamplePlugin/RegisterPluginAndStartStreamDeck.ps1
@@ -48,14 +48,14 @@ Get-Process -Name ("StreamDeck", $pluginName) -ErrorAction SilentlyContinue | St
 # Delete the target directory, make sure the deployment/copy is clean
 If (Test-Path $destDir) {
   Remove-Item -Recurse -Force -Path $destDir 
-  $bindir = $bindir +"\*"
 }
 
 # Then copy all deployment items to the plugin directory
 New-Item -Type Directory -Path $destDir -ErrorAction SilentlyContinue # | Out-Null
+$bindir = $bindir +"\*"
 Copy-Item -Path $bindir -Destination $destDir -Recurse
 
 
-Write-Host "Deployment complete. We will NOT restart the Stream Deck here, but will from the template..."
+Write-Host "Deployment complete. We will NOT restart the Stream Deck desktop application here, but will from the template..."
 # Start-Process $streamDeckExePath
 exit 0


### PR DESCRIPTION
In certain cases, PowerShell will write an error to the output for operations which legitimately fail. These don't need to be displayed to the user.

For operations where errors can occur, such as enumerating and stopping the processes (Stream Deck and Plugin's at this time), avoid showing an error to the user.