### PR TITLE
Add VSCode files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,19 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/osx,windows
+
+# Created by https://www.gitignore.io/api/visualstudiocode
+# Edit at https://www.gitignore.io/?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+# End of https://www.gitignore.io/api/visualstudiocode


### PR DESCRIPTION
Adding files and directories related to VSCode to the `.gitignore` file, from GitHub's [gitignore.io](gitignore.io) site.