### PR TITLE
small powershell file copy fix

### DIFF
--- a/src/SamplePlugin/RegisterPluginAndStartStreamDeck.ps1
+++ b/src/SamplePlugin/RegisterPluginAndStartStreamDeck.ps1
@@ -58,7 +58,6 @@ $bindir =  Join-Path $bindir "*"
 
 # Then copy all deployment items to the plugin directory
 New-Item -Type Directory -Path $destDir -ErrorAction SilentlyContinue # | Out-Null
-$bindir = $bindir +"\*"
 Copy-Item -Path $bindir -Destination $destDir -Recurse
 
 


### PR DESCRIPTION
extraneous $bindir concatenation causing issues with copying of files, removed that line of code so it copies over properly