### PR TITLE
Fixed and issue I found on first use that required IServiceProvider

### DIFF
--- a/src/StreamDeckLib/ActionManager.cs
+++ b/src/StreamDeckLib/ActionManager.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
@@ -24,6 +25,8 @@ namespace StreamDeckLib
 		// The logger we will receive when being instantiated. Defaults to a NullLogger is none is specified.
 		private readonly ILogger<ActionManager> _Logger;
 
+		private readonly IServiceProvider _serviceProvider;
+
 		#endregion
 
 
@@ -39,9 +42,10 @@ namespace StreamDeckLib
 		/// Initializes a new instance of the <see cref="T:StreamDeckLib.ActionManager"/> class.
 		/// </summary>
 		/// <param name="logger">An instance of a logger (<see cref="ILogger"/> class.</param>
-		public ActionManager(ILogger<ActionManager> logger = null) : this()
+		public ActionManager(ILogger<ActionManager> logger = null, IServiceProvider serviceProvider = null) : this()
 		{
 			this._Logger = logger ?? NullLoggerFactory.Instance.CreateLogger<ActionManager>();
+			this._serviceProvider = serviceProvider;
 		}
 
 		#endregion
@@ -140,7 +144,7 @@ namespace StreamDeckLib
 
 			if (this._Actions.ContainsKey(actionUUID))
 			{
-				var instance = Activator.CreateInstance(this._Actions[actionUUID]) as TActionType;
+				var instance = ActivatorUtilities.CreateInstance(this._serviceProvider, this._Actions[actionUUID]) as TActionType;
 				instance.Logger = _Logger;
 				instance.Manager = connectionManager;
 				return instance;
@@ -187,7 +191,7 @@ namespace StreamDeckLib
 			this._Logger?.LogTrace($"{nameof(ActionManager)}.{nameof(CreateActionInstanceByUUID)}(string, bool)");
 			if (this._Actions.ContainsKey(actionUuid))
 			{
-				var instance = Activator.CreateInstance(this._Actions[actionUuid]) as BaseStreamDeckAction;
+				var instance = ActivatorUtilities.CreateInstance(this._serviceProvider, this._Actions[actionUuid]) as BaseStreamDeckAction;
 				instance.Logger = _Logger;
 				instance.Manager = connectionManager;
 				return instance;

--- a/src/StreamDeckLib/ConnectionManager.cs
+++ b/src/StreamDeckLib/ConnectionManager.cs
@@ -40,11 +40,17 @@ namespace StreamDeckLib
 			_ActionManager = actionManager;
 			_logger = logger;
 
-			var myInfo = JsonConvert.DeserializeObject<Info>(options.Value.Info);
-			Info = myInfo;
-			_port = options.Value.Port;
-			_uuid = options.Value.PluginUUID;
-			_registerEvent = options.Value.RegisterEvent;
+			if (options.Value != null)
+			{
+				if (!string.IsNullOrEmpty(options.Value.Info))
+				{
+					var myInfo = JsonConvert.DeserializeObject<Info>(options.Value.Info);
+					Info = myInfo;
+				}
+				_port = options.Value.Port;
+				_uuid = options.Value.PluginUUID;
+				_registerEvent = options.Value.RegisterEvent;
+			}
 			_proxy = streamDeckProxy;
 		}
 


### PR DESCRIPTION
During my first use of the DI friendly library I found a couple of issues, this mainly centred around the IServiceProvider and how it was injected and or used.

When doing CreateInstance we need to add it to the IServiceProvider or the system will not work or be able to use it elsewhere