### PR TITLE
Category fix

### DIFF
--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/_StreamDeckPlugin_.csproj
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/_StreamDeckPlugin_.csproj
@@ -38,7 +38,7 @@
 	<!--Deployment files that must go with the build executable -->
 	<ItemGroup>
 		<Content Include="manifest.json">
-				<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 		<Content Include="appsettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -64,6 +64,12 @@
 		</Content>
 		<Content Include="images/pluginIcon@2x.png">
 				<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="images/category/categoryIcon.png">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="images/category/categoryIcon@2x.png">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 		<Content Include="images/Fritz.png">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Templates/StreamDeck.PluginTemplate.Csharp/content/manifest.json
+++ b/Templates/StreamDeck.PluginTemplate.Csharp/content/manifest.json
@@ -16,7 +16,7 @@
     }
   ],
 	"Category": "Your Plugin Category",
-	"CategoryIcon": "images/category/categoryIcon.png",
+	"CategoryIcon": "images/category/categoryIcon",
 	"Disabled":  false,
 	"Author": "Your Name",
 	"CodePathWin": "_StreamDeckPlugin_.exe",

--- a/src/SampleDIPlugin/SampleDIPlugin.csproj
+++ b/src/SampleDIPlugin/SampleDIPlugin.csproj
@@ -11,6 +11,8 @@
     <None Remove="images\actionDefaultImage@2x.png" />
     <None Remove="images\actionIcon.png" />
     <None Remove="images\actionIcon@2x.png" />
+    <None Remove="images\category\categoryIcon%402x.png" />
+    <None Remove="images\category\categoryIcon.png" />
     <None Remove="images\Fritz.png" />
     <None Remove="images\pluginIcon.png" />
     <None Remove="images\pluginIcon@2x.png" />
@@ -40,6 +42,12 @@
     <Content Include="images\actionIcon@2x.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
+    <Content Include="images\category\categoryIcon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="images\category\categoryIcon@2x.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="images\Fritz.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SampleDIPlugin/manifest.json
+++ b/src/SampleDIPlugin/manifest.json
@@ -30,7 +30,7 @@
 		}
 	],
 	"Category": "Fritz & Friends",
-	"CategoryIcon": "images/category/categoryIcon.png",
+	"CategoryIcon": "images/category/categoryIcon",
 	"Disabled":  false,
   "Author": "Jeffrey T. Fritz",
 	"CodePathWin": "SamplePlugin.cmd",

--- a/src/SamplePlugin/SamplePlugin.csproj
+++ b/src/SamplePlugin/SamplePlugin.csproj
@@ -11,6 +11,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <None Remove="Fritz.png" />
+	  <None Remove="images\category\categoryIcon%402x.png" />
+	  <None Remove="images\category\categoryIcon.png" />
 	  <None Remove="property_inspector\css\property-inspector.css" />
 	  <None Remove="property_inspector\css\sdpi.css" />
 	  <None Remove="property_inspector\js\property-inspector.js" />
@@ -51,6 +53,12 @@
 		</Content>
 		<Content Include="images/Fritz.png">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="images\category\categoryIcon.png">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="images\category\categoryIcon@2x.png">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 		<Content Include="manifest.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SamplePlugin/manifest.json
+++ b/src/SamplePlugin/manifest.json
@@ -30,7 +30,7 @@
 		}
 	],
 	"Category": "Fritz & Friends",
-	"CategoryIcon": "images/category/categoryIcon.png",
+	"CategoryIcon": "images/category/categoryIcon",
 	"Disabled":  false,
   "Author": "Jeffrey T. Fritz",
 	"CodePathWin": "SamplePlugin.cmd",

--- a/src/SampleWebPlugin/SampleWebPlugin.csproj
+++ b/src/SampleWebPlugin/SampleWebPlugin.csproj
@@ -9,6 +9,8 @@
     <None Remove="images\actionDefaultImage@2x.png" />
     <None Remove="images\actionIcon.png" />
     <None Remove="images\actionIcon@2x.png" />
+    <None Remove="images\category\categoryIcon%402x.png" />
+    <None Remove="images\category\categoryIcon.png" />
     <None Remove="images\Fritz.png" />
     <None Remove="images\pluginIcon.png" />
     <None Remove="images\pluginIcon@2x.png" />
@@ -34,6 +36,12 @@
     <Content Include="images\actionIcon@2x.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
+    <Content Include="images\category\categoryIcon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="images\category\categoryIcon@2x.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="images\Fritz.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SampleWebPlugin/manifest.json
+++ b/src/SampleWebPlugin/manifest.json
@@ -30,7 +30,7 @@
 		}
 	],
 	"Category": "Fritz & Friends",
-	"CategoryIcon": "images/category/categoryIcon.png",
+	"CategoryIcon": "images/category/categoryIcon",
 	"Disabled":  false,
   "Author": "Jeffrey T. Fritz",
 	"CodePathWin": "SamplePlugin.cmd",


### PR DESCRIPTION
#154 Category icons aren't used in template.

Updated the `manifest.json` `CategoryIcon` value to not include the file extension.
Set the category images output settings to copy.

Elgato Sample:

`"CategoryIcon": "plugin/images/actions/category",`
https://github.com/elgatosf/streamdeck-philipshue/blob/master/Sources/com.elgato.philips-hue.sdPlugin/manifest.json#L60

- category.png
- category@2x.png