### PR TITLE
Use platform agnostic StartsWith null check

### DIFF
--- a/src/StreamDeckLib/ConnectionManager.cs
+++ b/src/StreamDeckLib/ConnectionManager.cs
@@ -170,7 +170,7 @@ namespace StreamDeckLib
 
 				var jsonString = await _proxy.GetMessageAsString(token);
 
-				if (!string.IsNullOrEmpty(jsonString) && !jsonString.StartsWith("\0"))
+				if (!string.IsNullOrEmpty(jsonString) && !jsonString.StartsWith("\u0000", StringComparison.OrdinalIgnoreCase))
 				{
 					try
 					{


### PR DESCRIPTION
Found on OSX Catalina w/ .NET Core 3.1:

`StartsWith("\0")` always returns `true`

Implemented fix from the following discussion:

https://stackoverflow.com/questions/52395504/inconsistent-string-startswith-on-different-platforms