### PR TITLE
Fix null connection proxy

### DIFF
--- a/src/StreamDeckLib/ConnectionManager.cs
+++ b/src/StreamDeckLib/ConnectionManager.cs
@@ -51,7 +51,7 @@ namespace StreamDeckLib
 				_uuid = options.Value.PluginUUID;
 				_registerEvent = options.Value.RegisterEvent;
 			}
-			_proxy = streamDeckProxy;
+			_proxy = streamDeckProxy ?? new StreamDeckProxy();
 		}
 
 		private ConnectionManager(StreamDeckToolkitOptions options, ILoggerFactory loggerFactory = null, IStreamDeckProxy streamDeckProxy = null) : this()
@@ -61,7 +61,7 @@ namespace StreamDeckLib
 			_port = options.Port;
 			_uuid = options.PluginUUID;
 			_registerEvent = options.RegisterEvent;
-			_proxy = streamDeckProxy;
+			_proxy = streamDeckProxy ?? new StreamDeckProxy();
 
 			_LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
 			_logger = loggerFactory?.CreateLogger<ConnectionManager>();


### PR DESCRIPTION
Restores ability for non-DI plugins to init by defaulting to the StreamDeckProxy if no implementation is passed to `Initialize`.

Originally handled here: https://github.com/FritzAndFriends/StreamDeckToolkit/blob/a2ff6fbf100f8b0940ce51c62f672acbade56f48/src/StreamDeckLib/ConnectionManager.cs#L74

Removed in 4bba9ea98c44c6a1ac98ae64b67d6b6fa0617f2a

---

Perhaps I misunderstand how this newer version of the Toolkit is supposed to be used. Will only DI be supported? In that case, this PR is of no use.

I hit this issue of `_proxy` being null when trying `SamplePlugin` to debug the issue that led me to https://github.com/FritzAndFriends/StreamDeckToolkit/pull/161