### PR TITLE
Added state support to SetImageAsync

### DIFF
--- a/src/StreamDeckLib/ConnectionManager.cs
+++ b/src/StreamDeckLib/ConnectionManager.cs
@@ -239,7 +239,7 @@ namespace StreamDeckLib
 			await _proxy.SendStreamDeckEvent(args);
 		}
 
-		public async Task SetImageAsync(string context, string imageLocation)
+		public async Task SetImageAsync(string context, string imageLocation, int? state = null)
 		{
 
 			Debug.WriteLine($"Getting Image from {new FileInfo(imageLocation).FullName} on disk");
@@ -253,7 +253,8 @@ namespace StreamDeckLib
 				payload = new SetImageArgs.Payload
 				{
 					TargetType = SetTitleArgs.TargetType.HardwareAndSoftware,
-					image = $"data:image/{new FileInfo(imageLocation).Extension.ToLowerInvariant().Substring(1)};base64, {imgString}"
+					image = $"data:image/{new FileInfo(imageLocation).Extension.ToLowerInvariant().Substring(1)};base64, {imgString}",
+					state = state
 				}
 			};
 

--- a/src/StreamDeckLib/Messages/SetImageArgs.cs
+++ b/src/StreamDeckLib/Messages/SetImageArgs.cs
@@ -18,6 +18,8 @@ namespace StreamDeckLib.Messages
 			[JsonIgnore]
 			public TargetType TargetType { get; set; }
 
+			public int? state { get; set; }
+
 		}
 
 	}


### PR DESCRIPTION
Regarding Stream Deck documentation (https://developer.elgato.com/documentation/stream-deck/sdk/events-sent/#setimage)

setImage have a 3rd parameter called state. This parameter let set the image for a specific state.

As this parameter is optional call with 2 paramater will not need to be updated.

Tested with and without 3rd parameter.