### PR TITLE
Update install.md for powershell 7 instructions

### DIFF
--- a/docs/articles/install.md
+++ b/docs/articles/install.md
@@ -5,14 +5,13 @@
 Installing the template from your filesystem is useful for local testing of the template itself. If you are actively working on the template making changes, this is the route you need to use.
 
 To install, run the following command from the root of the repository.
-
-`dotnet new -i Templates/StreamDeck.PluginTemplate.Csharp`
+`dotnet new install StreamDeckPluginTemplate`
 
 To pick up any changes you have made to the template source, you must uninstall the template and reinstall it.
 
 To uninstall, run the following command from the root of the respository.
 
-**Windows:**  `dotnet new -u Templates/StreamDeck.PluginTemplate.Csharp`
+**Windows:** `dotnet new uninstall StreamDeckPluginTemplate`
 
 **OSX/Linux:** `dotnet new -u $PWD/Templates/StreamDeck.PluginTemplate.Csharp`
 


### PR DESCRIPTION
Technically this is two changes, first they changed the format of the command, and it seems they removed the `Templates` prefix as well.

```
❯ dotnet new -i Templates/StreamDeck.PluginTemplate.Csharp
Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.
For more information, run:
   dotnet new install -h

❯ dotnet new install Templates/StreamDeck.PluginTemplate.Csharp
The following template packages will be installed:
   Templates/StreamDeck.PluginTemplate.Csharp

Templates/StreamDeck.PluginTemplate.Csharp is not supported.

❯ dotnet new install StreamDeckPluginTemplate
The following template packages will be installed:
   StreamDeckPluginTemplate

Success: StreamDeckPluginTemplate::0.5.2040 installed the following templates:
Template Name       Short Name         Language  Tags
------------------  -----------------  --------  ------------------------
Stream Deck Plugin  streamdeck-plugin  [C#]      Console/StreamDeckPlugin
```